### PR TITLE
Add Modrinth to the list of reputable plugin sources.

### DIFF
--- a/docs/getting-started/plugins.mdx
+++ b/docs/getting-started/plugins.mdx
@@ -27,6 +27,7 @@ Plugins are a great way to extend your server with new features. They allow you 
 For security and reliability, only install plugins from reputable sources:
 
 - [Hangar](https://hangar.papermc.io) (recommended)
+- [Modrinth](https://modrinth.com/plugins)
 - [SpigotMC](https://www.spigotmc.org/resources)
 - [BukkitDev](https://dev.bukkit.org/bukkit-plugins)
 - Official GitHub repositories


### PR DESCRIPTION
Specifically it points to the plugin category on Modrinth (https://modrinth.com/plugins)

I find Modrinth to be a really nice source for plugins, especially with their version selector upon pressing Download, and am not aware of any major controversy with them. Basically, I just think they're a good source to mention.