### PR TITLE
Docs/horizon dependency resolution

### DIFF
--- a/src/content/docs/horizon/dev/api.mdx
+++ b/src/content/docs/horizon/dev/api.mdx
@@ -214,4 +214,5 @@ provider.invoke("Example!");
 Horizon provides a `"server_main"` entrypoint for plugins, which is executed on startup after the server build
 information impl is created, which is very similar to the fabric loader `"server"` entrypoint. All plugins using this
 must implement the `DedicatedServerInitializer` class.
+
 Horizon also provides a `"server_postbootstrap"` entrypoint for plugins, which is executed after the server has completed its bootstrap process. Plugins using this must implement the `ServerPostBootstrapEntrypoint` class.

--- a/src/content/docs/horizon/dev/api.mdx
+++ b/src/content/docs/horizon/dev/api.mdx
@@ -92,14 +92,17 @@ HorizonLoader horizon = HorizonLoader.getInstance();
 // This includes *all* Horizon plugins, nested and unnested
 PluginTree plugins = horizon.getPlugins();
 for (HorizonPlugin plugin : plugins.getAll()) {
-    // The HorizonMetadata class acts as an object representation of the
+    // The HorizonPluginMetadata class acts as an object representation of the
     // Horizon plugin json file. It contains the name, version, mixins,
     // ats, api version, etc.
-    HorizonMetadata metadata = plugin.pluginMetadata();
+    HorizonPluginMetadata metadata = plugin.pluginMetadata();
     getLogger().info("Hello " + metadata.name() + "!");
 
-    // The plugin identifier is the same as the 'name' entry in the metadata
-    String id = plugin.identifier();
+    // The plugin identifier is the core plugin ID that is used for things like dependencies, and other plugins to reference it.
+    String id = plugin.id();
+
+    // Identifiers include the main plugin ID and any additional aliases.
+    Set<String> identifiers = plugin.identifiers();
 
     // The HorizonPlugin also provides the FileJar instance that is tied
     // to the plugin, and also a FileSystem via HorizonPlugin#fileSystem()
@@ -211,3 +214,4 @@ provider.invoke("Example!");
 Horizon provides a `"server_main"` entrypoint for plugins, which is executed on startup after the server build
 information impl is created, which is very similar to the fabric loader `"server"` entrypoint. All plugins using this
 must implement the `DedicatedServerInitializer` class.
+Horizon also provides a `"server_postbootstrap"` entrypoint for plugins, which is executed after the server has completed its bootstrap process. Plugins using this must implement the `ServerPostBootstrapEntrypoint` class.

--- a/src/content/docs/horizon/dev/intro.mdx
+++ b/src/content/docs/horizon/dev/intro.mdx
@@ -22,6 +22,8 @@ files, but not completely. Here is an example:
 
 ```json5
 {
+  // The plugin ID, which is used for identifying the plugin in the dependency resolution system. If not specified, it will be the same as the name, but with all lowercase and spaces replaced with dashes.
+  "id": "testplugin",
   "name": "TestPlugin",
   "version": "1.0.0-SNAPSHOT",
   "description": "Hello world",
@@ -49,7 +51,7 @@ files, but not completely. Here is an example:
   "wideners": [
     "widener.at"
   ],
-  // This is your dependencies block for Horizon TODO - make this system
+  // This is your dependencies block for Horizon
   "dependencies": {
     /*
       The "minecraft" value is optional. It's a version constraint that
@@ -65,11 +67,20 @@ files, but not completely. Here is an example:
     */
     "java": "25",
     // Literally same thing as the other 2, but for ASM
-    "asm": "9.0"
+    "asm": "9.0",
+
+    /*
+      You may depend on third-party plugins, but they must be Horizon plugins.
+      Dependencies on Paper plugins are not supported due to classloader separation. This is a strict requirement.
+    */
+    "other-plugin": ">=1.0.0"
   }
 }
 ```
 
+- `provides` - This is a `String[]` option that defines additional IDs that this plugin provides. 
+  This allows a plugin to act as a drop-in replacement for another plugin API, making it 
+  interchangeable in dependency resolution.
 - `mixins` - This is a `String[]` option that defines the SpongePowered mixin configuration files in your plugin
   artifact. Like if it were `test.mixins.json`, the entry should be in the root of your resources, named
   `test.mixins.json`
@@ -123,6 +134,7 @@ All Paper plugins will be loaded as usual, and their plugin data folders will re
 will function exactly the same, and will load
 mixins like normal. External libraries will be appended to the game classpath with Ember, as if they were libraries
 added by the server JAR, and will be accessible after Horizon launches the game.
+All plugins packaged using JIJ are treated as a bundle. In the `/plugins` command, only the main plugin will be displayed. To view all plugins within a bundle, use `/plugins <plugin>`.
 
 ### Gradle Plugin
 
@@ -175,6 +187,9 @@ dependencies {
     includeMixinPlugin("io.canvasmc:nice-horizon-plugin:1.0.0")
     includePlugin("io.canvasmc:nice-plugin:1.0.0")
     includeLibrary("io.canvasmc:nice-library:1.0.0")
+
+    // You can use this configuration for horizon plugin dependencies that need in compilation, but you don't want to package them into your artifact. This is useful for plugins that are going to be provided in runtime by the server or other plugins.
+    mixinPluginImplementation("io.canvasmc:other-nice-horizon-plugin:1.0.0")
 }
 ```
 

--- a/src/content/docs/horizon/dev/intro.mdx
+++ b/src/content/docs/horizon/dev/intro.mdx
@@ -191,8 +191,8 @@ dependencies {
     includePlugin("io.canvasmc:nice-plugin:1.0.0")
     includeLibrary("io.canvasmc:nice-library:1.0.0")
 
-    // You can use this configuration for horizon plugin dependencies that need in compilation, but you don't want to package them into your artifact. This is useful for plugins that are going to be provided in runtime by the server or other plugins.
-    mixinPluginImplementation("io.canvasmc:other-nice-horizon-plugin:1.0.0")
+    // Use this configuration for Horizon plugin dependencies required at compile time but not bundled into the final artifact, as they are automatically added to the development server runtime.
+    pluginImplementation("io.canvasmc:other-nice-horizon-plugin:1.0.0")
 }
 ```
 

--- a/src/content/docs/horizon/dev/intro.mdx
+++ b/src/content/docs/horizon/dev/intro.mdx
@@ -192,7 +192,7 @@ dependencies {
     includeLibrary("io.canvasmc:nice-library:1.0.0")
 
     // Use this configuration for Horizon plugin dependencies required at compile time but not bundled into the final artifact, as they are automatically added to the development server runtime.
-    pluginImplementation("io.canvasmc:other-nice-horizon-plugin:1.0.0")
+    runtimePlugin("io.canvasmc:other-nice-horizon-plugin:1.0.0")
 }
 ```
 

--- a/src/content/docs/horizon/dev/intro.mdx
+++ b/src/content/docs/horizon/dev/intro.mdx
@@ -100,6 +100,9 @@ More information on Mixins and ATs is available in the [Mixins && ATs](/horizon/
 
 :::
 
+Plugins dependencies are resolved automatically by Horizon at startup.
+Plugins are loaded in dependency order, and missing or incompatible dependencies will prevent the plugin from loading.
+
 To check if your plugin is loaded as a Horizon plugin successfully, you can read the plugin data tree in the startup
 logs, which will look similar to this:
 

--- a/src/content/docs/horizon/dev/intro.mdx
+++ b/src/content/docs/horizon/dev/intro.mdx
@@ -51,7 +51,7 @@ files, but not completely. Here is an example:
   "wideners": [
     "widener.at"
   ],
-  // This is your dependencies block for Horizon
+  // Dependencies use semantic versioning (SemVer) for version specification and compatibility.
   "dependencies": {
     /*
       The "minecraft" value is optional. It's a version constraint that


### PR DESCRIPTION
Updates Horizon documentation to reflect recent changes:
- Added server_postbootstrap entrypoint
- Clarified dependency rules and SemVer usage
- Improved identifiers documentation
- Documented JIJ bundle behavior
- General wording and clarity improvements